### PR TITLE
Update Server resource fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+See the [1&1 Provider documentation](https://www.terraform.io/docs/providers/oneandone/index.html) to get started using the 1&1 provider.
 
 Developing the Provider
 ---------------------------

--- a/oneandone/resource_oneandone_server.go
+++ b/oneandone/resource_oneandone_server.go
@@ -52,6 +52,7 @@ func resourceOneandOneServer() *schema.Resource {
 			"password": {
 				Type:      schema.TypeString,
 				Optional:  true,
+				Computed:  true,
 				Sensitive: true,
 			},
 			"datacenter": {

--- a/oneandone/resource_oneandone_server.go
+++ b/oneandone/resource_oneandone_server.go
@@ -486,7 +486,6 @@ func resourceOneandOneServerUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if hw != nil && (hw.CoresPerProcessor > 0 || hw.Vcores > 0 || hw.Ram > 0) {
-		log.Println("[DEBUG] HARWARE IS", hw)
 		srv, err := config.API.UpdateServerHardware(d.Id(), hw)
 		if err != nil {
 			return err

--- a/oneandone/resource_oneandone_server.go
+++ b/oneandone/resource_oneandone_server.go
@@ -472,6 +472,29 @@ func resourceOneandOneServerUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	hw := &oneandone.Hardware{}
+
+	if d.HasChange("vcores") {
+		hw.Vcores = d.Get("vcores").(int)
+	}
+
+	if d.HasChange("cores_per_processor") {
+		hw.CoresPerProcessor = d.Get("cores_per_processor").(int)
+	}
+	if d.HasChange("ram") {
+		hw.Ram = float32(d.Get("ram").(float64))
+	}
+
+	if hw != nil && (hw.CoresPerProcessor > 0 || hw.Vcores > 0 || hw.Ram > 0) {
+		log.Println("[DEBUG] HARWARE IS", hw)
+		srv, err := config.API.UpdateServerHardware(d.Id(), hw)
+		if err != nil {
+			return err
+		}
+
+		err = config.API.WaitForState(srv, "POWERED_ON", 30, config.Retries)
+	}
+
 	return resourceOneandOneServerRead(d, meta)
 }
 

--- a/oneandone/resource_oneandone_server_test.go
+++ b/oneandone/resource_oneandone_server_test.go
@@ -52,6 +52,48 @@ func TestAccOneandoneServer_Basic(t *testing.T) {
 	})
 }
 
+func TestAccOneandoneServer_Hardware(t *testing.T) {
+	var server oneandone.Server
+
+	name := "test_server_hardware"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDOneandoneServerDestroyCheck,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckOneandoneServer_basic, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+					testAccCheckOneandoneServerExists("oneandone_server.server", &server),
+					resource.TestCheckResourceAttr("oneandone_server.server", "vcores", "1"),
+					resource.TestCheckResourceAttr("oneandone_server.server", "ram", "2"),
+					resource.TestCheckResourceAttr("oneandone_server.server", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckOneandoneServer_hardware, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+					testAccCheckOneandoneServerExists("oneandone_server.server", &server),
+					resource.TestCheckResourceAttr("oneandone_server.server", "vcores", "2"),
+					resource.TestCheckResourceAttr("oneandone_server.server", "ram", "2.5"),
+					resource.TestCheckResourceAttr("oneandone_server.server", "name", name),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDOneandoneServerDestroyCheck(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "oneandone_server" {
@@ -120,6 +162,24 @@ resource "oneandone_server" "server" {
   vcores = 1
   cores_per_processor = 1
   ram = 2
+  password = "Kv40kd8PQb"
+  hdds = [
+    {
+      disk_size = 20
+      is_main = true
+    }
+  ]
+}`
+
+const testAccCheckOneandoneServer_hardware = `
+resource "oneandone_server" "server" {
+  name = "%s"
+  description = "%s"
+  image = "ubuntu"
+  datacenter = "GB"
+  vcores = 2
+  cores_per_processor = 1
+  ram = 2.5
   password = "Kv40kd8PQb"
   hdds = [
     {


### PR DESCRIPTION
Updated README.md
Fixes #1 
Output for acceptance test TestAccOneandoneServer_Hardware
```$ make testacc TEST=./oneandone/ TESTARGS='-run=TestAccOneandoneServer_Hardware'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./oneandone/ -v -run=TestAccOneandoneServer_Hardware -timeout 120m
=== RUN   TestAccOneandoneServer_Hardware
--- PASS: TestAccOneandoneServer_Hardware (206.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-oneandone/oneandone   206.914s
```