### PR TITLE
server: allow to pre-depoly a ssh-public-key

### DIFF
--- a/oneandone/resource_oneandone_server.go
+++ b/oneandone/resource_oneandone_server.go
@@ -54,6 +54,13 @@ func resourceOneandOneServer() *schema.Resource {
 			"ssh_key_path": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
+			},
+			"ssh_key_public": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"ssh_key_path"},
 			},
 			"password": {
 				Type:      schema.TypeString,
@@ -246,6 +253,10 @@ func resourceOneandOneServerCreate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		req.SSHKey = publicKey
+	}
+
+	if raw, ok := d.GetOk("ssh_key_public"); ok {
+		req.SSHKey = raw.(string)
 	}
 
 	var password string

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -21,7 +21,8 @@ resource "oneandone_server" "server" {
   vcores = 1
   cores_per_processor = 1
   ram = 2
-  ssh_key_path = "/path/to/prvate/ssh_key"
+  ssh_key_path = "/path/to/private/ssh_key"
+  ssh_key_public = "${file("/path/to/public/key.pub")}"
   hdds = [
     {
       disk_size = 60
@@ -58,6 +59,7 @@ The following arguments are supported:
 * `password` - (Optional) Desired password.
 * `ram` -(Optional) Size of ram.
 * `ssh_key_path` - (Optional) Path to private ssh key
+* `ssh_key_public` - (Optional) The public key data in OpenSSH authorized_keys format.
 * `vcores` -(Optional) Number of virtual cores.
 
 Either `fixed_instance_size` or all of `vcores`, `cores_per_processor`, `ram` and `hdds` are required.


### PR DESCRIPTION
this allows to pre-deploy a ssh-public-key to a server without the requirement to have the private key within terraform.

@jasminSPC should i also create an issue for this ?