### PR TITLE
vendor: Bump SDK to 1.1.1

### DIFF
--- a/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/README.md
+++ b/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/README.md
@@ -1,8 +1,8 @@
 # 1&amp;1  Cloudserver Go SDK
 
-The 1&amp;1  Go SDK is a Go library designed for interaction with the 1&amp;1  cloud platform over the REST API.
+The 1&amp;1  Go SDK is a Go library designed for interaction with the 1&amp;1  cloud platform over the REST API. 
 
-This guide contains instructions on getting started with the library and automating various management tasks available through the 1&amp;1  Cloud Panel UI.
+This guide contains instructions on getting started with the library and automating various management tasks available through the 1&amp;1  Cloud Panel UI. For more information on the 1&amp;1  Cloudserver Go SDK see the [1&1 Community Portal](https://www.1and1.com/cloud-community/).
 
 ## Table of Contents
 
@@ -349,17 +349,53 @@ If any of the parameters `sort`, `query` or `fields` is set to an empty string, 
 **Create an image:**
 
 ```
-request := oneandone.ImageConfig {
+request := oneandone.ImageRequest {
     Name: image_name,
     Description: image_description,
+    Source: 'server',
     ServerId: server_id, 
     Frequency: image_frequenct,
     NumImages: number_of_images,
+    DatacenterId: datacenter_id,
   }
 
 image_id, image, err = api.CreateImage(&request)
 ```
-All fields except `Description` are required. `Frequency` may be set to `"ONCE"`, `"DAILY"` or `"WEEKLY"`.
+`Description`, `Source` and `DatacenterId` are optional fields when creating a server image. `Frequency` may be set to `"ONCE"`, `"DAILY"` or `"WEEKLY"`.
+
+Use the same method to import an existing ISO image.
+
+```
+request := oneandone.ImageRequest {
+    Name: image_name,
+    Description: image_description,
+    Source: 'iso',
+    Url: image_url,
+    Type: image_type,
+    OsId: os_id,
+    DatacenterId: datacenter_id,
+  }
+```
+`Type` should be set to `os` or `app`. `OsId` is required if the image type is `os`.
+
+To import a `vdi`, `qcow`, `qcow2`, `vhd`, `vhdx` or `vmdk` image, instantiate the image request as follows:
+
+```
+request := oneandone.ImageRequest {
+    Name: image_name,
+    Description: image_description,
+    Source: 'image',
+    Url: image_url,
+    OsId: os_id,
+    DatacenterId: datacenter_id,
+  }
+```
+
+
+**List image OSes:**
+
+`imageOSes, err = api.ListImageOs()`
+
 
 **Update an image:**
 
@@ -1856,7 +1892,7 @@ func (api *API) CreateFirewallPolicy(fp_data *FirewallPolicyRequest) (string, *F
 ```
 
 ```Go
-func (api *API) CreateImage(request *ImageConfig) (string, *Image, error)
+func (api *API) CreateImage(request *ImageRequest) (string, *Image, error)
 ```
 
 ```Go
@@ -2189,6 +2225,10 @@ func (api *API) ListFirewallPolicyServerIps(fp_id string) ([]ServerIpInfo, error
 
 ```Go
 func (api *API) ListFixedInstanceSizes() ([]FixedInstanceInfo, error)
+```
+
+```Go
+func (api *API) ListImageOs(args ...interface{}) ([]ImageOs, error)
 ```
 
 ```Go

--- a/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/images.go
+++ b/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/images.go
@@ -6,15 +6,19 @@ import (
 
 type Image struct {
 	idField
-	ImageConfig
+	nameField
+	descField
 	MinHddSize   int         `json:"min_hdd_size"`
-	Architecture *int        `json:"os_architecture"`
+	Architecture *int        `json:"architecture,omitempty"`
+	NumImages    *int        `json:"num_images,omitempty"`
+	Frequency    string      `json:"frequency,omitempty"`
+	ServerId     string      `json:"server_id,omitempty"`
 	CloudPanelId string      `json:"cloudpanel_id,omitempty"`
 	CreationDate string      `json:"creation_date,omitempty"`
 	State        string      `json:"state,omitempty"`
 	OsImageType  string      `json:"os_image_type,omitempty"`
-	OsFamily     string      `json:"os_family,omitempty"`
 	Os           string      `json:"os,omitempty"`
+	OsFamily     string      `json:"os_family,omitempty"`
 	OsVersion    string      `json:"os_version,omitempty"`
 	Type         string      `json:"type,omitempty"`
 	Licenses     []License   `json:"licenses,omitempty"`
@@ -23,12 +27,25 @@ type Image struct {
 	ApiPtr
 }
 
-type ImageConfig struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	Frequency   string `json:"frequency,omitempty"`
-	ServerId    string `json:"server_id,omitempty"`
-	NumImages   int    `json:"num_images"`
+type ImageRequest struct {
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Frequency    string `json:"frequency,omitempty"`
+	ServerId     string `json:"server_id,omitempty"`
+	DatacenterId string `json:"datacenter_id,omitempty"`
+	Source       string `json:"source,omitempty"`
+	Url          string `json:"url,omitempty"`
+	OsId         string `json:"os_id,omitempty"`
+	Type         string `json:"type,omitempty"`
+	NumImages    *int   `json:"num_images,omitempty"`
+}
+
+type ImageOs struct {
+	idField
+	Architecture *int   `json:"architecture,omitempty"`
+	Os           string `json:"os,omitempty"`
+	OsFamily     string `json:"os_family,omitempty"`
+	OsVersion    string `json:"os_version,omitempty"`
 }
 
 // GET /images
@@ -48,8 +65,23 @@ func (api *API) ListImages(args ...interface{}) ([]Image, error) {
 	return result, nil
 }
 
+// GET /images/os
+func (api *API) ListImageOs(args ...interface{}) ([]ImageOs, error) {
+	url, err := processQueryParams(createUrl(api, imagePathSegment, "os"), args...)
+	if err != nil {
+		return nil, err
+	}
+	result := []ImageOs{}
+	err = api.Client.Get(url, &result, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // POST /images
-func (api *API) CreateImage(request *ImageConfig) (string, *Image, error) {
+func (api *API) CreateImage(request *ImageRequest) (string, *Image, error) {
 	res := new(Image)
 	url := createUrl(api, imagePathSegment)
 	err := api.Client.Post(url, &request, &res, http.StatusAccepted)

--- a/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/pricing.go
+++ b/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/pricing.go
@@ -21,10 +21,10 @@ type serverPricing struct {
 }
 
 type pricingItem struct {
-	Name       string `json:"name,omitempty"`
-	GrossPrice string `json:"price_gross,omitempty"`
-	NetPrice   string `json:"price_net,omitempty"`
-	Unit       string `json:"unit,omitempty"`
+	Name       string  `json:"name,omitempty"`
+	GrossPrice float64 `json:"price_gross"`
+	NetPrice   float64 `json:"price_net"`
+	Unit       string  `json:"unit,omitempty"`
 }
 
 // GET /pricing

--- a/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/restclient.go
+++ b/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/restclient.go
@@ -13,13 +13,18 @@ import (
 )
 
 type restClient struct {
-	token string
+	token     string
+	transport http.RoundTripper
 }
 
 func newRestClient(token string) *restClient {
 	restClient := new(restClient)
 	restClient.token = token
 	return restClient
+}
+
+func (c *restClient) SetTransport(transport http.RoundTripper) {
+	c.transport = transport
 }
 
 func (c *restClient) Get(url string, result interface{}, expectedStatus int) error {
@@ -53,6 +58,11 @@ func (c *restClient) doRequest(url string, method string, requestBody interface{
 	request.Header.Add("X-Token", c.token)
 	request.Header.Add("Content-Type", "application/json")
 	client := http.Client{}
+
+	if c.transport != nil {
+		client.Transport = c.transport
+	}
+
 	response, err := client.Do(request)
 	if err = isError(response, expectedStatus, err); err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,12 @@
 	"ignore": "appengine test github.com/hashicorp/nomad/ github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "aABATU51PlDHfGeSe5cc9udwSXg=",
+			"checksumSHA1": "mHfkmdHUo67vJXvBHrWAJlhR818=",
 			"path": "github.com/1and1/oneandone-cloudserver-sdk-go",
-			"revision": "5678f03fc801525df794f953aa82f5ad7555a2ef",
-			"revisionTime": "2016-08-11T22:04:02Z"
+			"revision": "474e95802ccb9ae83b1969ef51b0ab545f51d4c8",
+			"revisionTime": "2017-09-15T08:18:10Z",
+			"version": "v1.1.1",
+			"versionExact": "v1.1.1"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",


### PR DESCRIPTION
This is mainly to allow us to leverage https://github.com/1and1/oneandone-cloudserver-sdk-go/pull/15
